### PR TITLE
minor conanfile fix (openssl dependency didn't work, now using openssl/1.1.1h

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ class RabbitMQConan(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False]}
     exports = "FindRabbitmqc.cmake"
     default_options = "shared=True", "fPIC=True"
-    requires = ("OpenSSL/1.0.2n@conan/stable")
+    requires = ("openssl/1.1.1h")
     generators = "cmake"
     unzipped_name = "rabbitmq-c-%s" % version
     zip_name = "%s.tar.gz" % unzipped_name
@@ -52,7 +52,7 @@ endif()""", "")
         cmake = CMake(self)
 
         # Use dependency version of openssl
-        openssl_root_dir = self.deps_cpp_info["OpenSSL"].rootpath
+        openssl_root_dir = self.deps_cpp_info["openssl"].rootpath
         cmake.definitions['OPENSSL_ROOT_DIR'] = openssl_root_dir
         cmake.definitions['BUILD_EXAMPLES'] = "OFF"  # Don't need to build examples
         cmake.definitions['BUILD_TESTS'] = "OFF"  # Don't need to build tests


### PR DESCRIPTION
I had this message while trying to `conan create .` fixed by using case sensitive dependency mention (cached openssl, actually)

<img width="913" alt="image" src="https://user-images.githubusercontent.com/12792352/107464515-8a422800-6b71-11eb-8d2c-b817454f1b5f.png">
